### PR TITLE
Fixed condition for calling `findMacaroonPath`

### DIFF
--- a/lib/lnd-rpc.js
+++ b/lib/lnd-rpc.js
@@ -37,7 +37,7 @@ async function connect({
     certPath = findCertPath();
   }
 
-  if (useMacaroons && (!macaroonPath || !macaroon)) {
+  if (useMacaroons && !macaroonPath && !macaroon) {
     macaroonPath = findMacaroonPath();
   }
 


### PR DESCRIPTION
This fixes a condition error where if a `macaroonPath` is set it will still call `findMacaroonPath`.